### PR TITLE
README: let composer pick last version

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The prefixed `.phar` distribution is built using [phpstan-compiler](https://gith
 Install the package
 
 ```bash
-composer require --dev phpstan/phpstan-shim:^0.7@dev
+composer require --dev phpstan/phpstan-shim
 ```
 
 and use it like the original executable


### PR DESCRIPTION
This way it'll install the most recent version. Also prevent manual version bumping - now it's 0.8 and not 0.7.