### PR TITLE
README: add conflict install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 The prefixed `.phar` distribution is built using [phpstan-compiler](https://github.com/fprochazka/phpstan-compiler)
 
+It cannot be installed along with classic `phsptan/phpstan` package.
+
+
 ## Usage
 
 Install the package
@@ -22,7 +25,7 @@ Check out the main repo for more options https://github.com/phpstan/phpstan
 
 It is recommended, that you set a `tmpDir` in your `phpstan.neon`, otherwise it uses the system temp directory.
 
-```
+```yaml
 parameters:
     tmpDir: var/cache/phpstan
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The prefixed `.phar` distribution is built using [phpstan-compiler](https://github.com/fprochazka/phpstan-compiler)
 
-It cannot be installed along with classic `phsptan/phpstan` package.
+It cannot be installed along with classic `phpstan/phpstan` package.
 
 
 ## Usage


### PR DESCRIPTION
It fails autoloading otherwise:

![image](https://user-images.githubusercontent.com/924196/30473670-730f03e6-9a01-11e7-8920-e8c237cad78e.png)

Not sure exactly why.

- Linux: Ubuntu 17.04