### PR TITLE
Allow to install nikic/php-parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ vendor/bin/phpstan.phar analyse src
 
 Check out the main repo for more options [https://github.com/phpstan/phpstan](https://github.com/phpstan/phpstan).
 
-For technical reasons, if your project depends on `nikic/php-parser` package, make sure you have the `PHAR` PHP extension enabled, otherwise the composer autoloader will not work as expected.
-
 ## Configuration
 
 It is recommended that you set a `tmpDir` in your `phpstan.neon`, otherwise it uses the system temp directory.

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,0 @@
-<?php
-
-if (extension_loaded('phar')) {
-	require_once 'phar://' . __DIR__ . '/phpstan.phar/vendor/autoload.php';
-}

--- a/composer.json
+++ b/composer.json
@@ -6,8 +6,7 @@
 		"php": "~7.1"
 	},
 	"replace": {
-		"phpstan/phpstan": "self.version",
-		"nikic/php-parser": "^4.0.2"
+		"phpstan/phpstan": "self.version"
 	},
 	"bin": [
 		"phpstan",
@@ -17,8 +16,5 @@
 		"branch-alias": {
 			"dev-master": "0.10-dev"
 		}
-	},
-	"autoload": {
-		"files": ["bootstrap.php"]
 	}
 }


### PR DESCRIPTION
... and remove changes introduced in 5e9b61d366911012d4c8ddc5b9d97f51f20545af

Changes from 5e9b61d366911012d4c8ddc5b9d97f51f20545af is redundant with
this commit as there is no need to load dependencies from the PHAR
itself.

NOTE: Adding a note that I do not know what the reasoning behind adding a replace in the first place, only that I can't see the need for it now.