### PR TITLE
Add a check for phar in stream wrappers.

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,9 @@
 <?php
 
-if (in_array('phar', stream_get_wrappers()) && extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
+if (!in_array('phar', stream_get_wrappers())) {
+	throw new \Exception('Phar wrapper is not registered. Please review your php.ini settings');
+}
+
+if (extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
 	require_once 'phar://' . __DIR__ . '/phpstan.phar/vendor/autoload.php';
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,5 +1,5 @@
 <?php
 
-if (extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
+if (in_array('phar', stream_get_wrappers()) && extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
 	require_once 'phar://' . __DIR__ . '/phpstan.phar/vendor/autoload.php';
 }

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,7 +1,7 @@
 <?php
 
-if (!in_array('phar', stream_get_wrappers())) {
-	throw new \Exception('Phar wrapper is not registered. Please review your php.ini settings');
+if (!in_array('phar', stream_get_wrappers(), true)) {
+	throw new \Exception('Phar wrapper is not registered. Please review your php.ini settings.');
 }
 
 if (extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {


### PR DESCRIPTION
This resolves an issue whereby the phpstan phar would try to be loaded even if
phar has not been registered as a stream wrapper in PHP.

This is prevalant in Magento >=2.2.8 as there now exists a line which unregisters 'phar' from stream wrappers in the bootstrap.php file.

https://magento.com/security/patches/magento-2.3.1-2.2.8-and-2.1.17-security-update (`PRODSECBUG-2261: Arbitrary code execution due to unsafe deserialization of a PHP archive`)

If PhpStan is loaded via the composer autoloader it causes magento commands to fail with this error - 

```
PHP Warning:  require_once(): Unable to find the wrapper "phar" - did you forget to enable it when you configured PHP? in /app/vendor/phpstan/phpstan-shim/bootstrap.php on line 4
```