### PR TITLE
Only autoload from phar when phar wrapper available

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -1,9 +1,5 @@
 <?php
 
-if (!in_array('phar', stream_get_wrappers(), true)) {
-	throw new \Exception('Phar wrapper is not registered. Please review your php.ini settings.');
-}
-
-if (extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
+if (in_array('phar', stream_get_wrappers()) && extension_loaded('phar') && !defined('__PHPSTAN_RUNNING__')) {
 	require_once 'phar://' . __DIR__ . '/phpstan.phar/vendor/autoload.php';
 }


### PR DESCRIPTION
I am not sure why this auto-loading is required... but at least it should not break applications where the phar wrapper is not registered / unregistered. e.g. in a Magento 2 development environment where development composer dependencies are installed as well bin/magento fails to run because phar wrapper is unregistered (see: https://github.com/magento/magento2/blob/2.3-develop/app/bootstrap.php#L12) and this bootstrap.php runs since it is autoloaded (see: https://github.com/phpstan/phpstan-shim/blob/master/composer.json#L23).

We can get around the issue by using phpstan/phpstan package instead... but would be nice to use the phar instead to avoid running into dependency conflicts later on.